### PR TITLE
fix(SKILL): description format

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,16 @@
 ---
 name: frappe-dev
-description: Builds full-stack Frappe Framework applications end-to-end. Use this skill any time the user mentions: creating or modifying a DocType, writing a controller or lifecycle hook, adding a whitelisted API, setting up a new Frappe app or bench site, building a desk form or list view, creating portal pages, writing background jobs or scheduled tasks, managing permissions or roles, writing Frappe tests, or working with frappe.db / frappe.qb. Also applies when the user says things like "how do I hook into save", "add a field to a DocType", "create a REST endpoint in Frappe", "run bench migrate", or "install an app on a site" — even if they don't explicitly say "Frappe".
+description: >-
+  Builds full-stack Frappe Framework applications end-to-end.
+  Use this skill any time the user mentions: creating or modifying a DocType,
+  writing a controller or lifecycle hook, adding a whitelisted API, setting up
+  a new Frappe app or bench site, building a desk form or list view, creating
+  portal pages, writing background jobs or scheduled tasks, managing permissions
+  or roles, writing Frappe tests, or working with frappe.db / frappe.qb.
+  Also applies when the user says things like "how do I hook into save",
+  "add a field to a DocType", "create a REST endpoint in Frappe",
+  "run bench migrate", or "install an app on a site" — even if they don't
+  explicitly say "Frappe".
 ---
 
 # Frappe Full-Stack App Builder


### PR DESCRIPTION
Resolve: #2

---

**This PR fix this error when run installation command:**

`npx skills add netchampfaris/frappe-agent-skills --skill frappe-dev`

███████╗██╗  ██╗██╗██╗     ██╗     ███████╗
██╔════╝██║ ██╔╝██║██║     ██║     ██╔════╝
███████╗█████╔╝ ██║██║     ██║     ███████╗
╚════██║██╔═██╗ ██║██║     ██║     ╚════██║
███████║██║  ██╗██║███████╗███████╗███████║
╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝╚══════╝

┌   skills 
│
◇  Source: https://github.com/netchampfaris/frappe-agent-skills.git
│
◇  Repository cloned
│
◇  No skills found
│
└  No valid skills found. Skills require a SKILL.md with name and description.