### PR TITLE
Fix SKILL.md frontmatter parsing

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: frappe-dev
-description: Builds full-stack Frappe Framework applications end-to-end. Use this skill any time the user mentions: creating or modifying a DocType, writing a controller or lifecycle hook, adding a whitelisted API, setting up a new Frappe app or bench site, building a desk form or list view, creating portal pages, writing background jobs or scheduled tasks, managing permissions or roles, writing Frappe tests, or working with frappe.db / frappe.qb. Also applies when the user says things like "how do I hook into save", "add a field to a DocType", "create a REST endpoint in Frappe", "run bench migrate", or "install an app on a site" — even if they don't explicitly say "Frappe".
+description: >-
+  Builds full-stack Frappe Framework applications end-to-end. Use this skill any
+  time the user mentions: creating or modifying a DocType, writing a controller
+  or lifecycle hook, adding a whitelisted API, setting up a new Frappe app or
+  bench site, building a desk form or list view, creating portal pages, writing
+  background jobs or scheduled tasks, managing permissions or roles, writing
+  Frappe tests, or working with frappe.db / frappe.qb. Also applies when the
+  user says things like "how do I hook into save", "add a field to a DocType",
+  "create a REST endpoint in Frappe", "run bench migrate", or "install an app on
+  a site" — even if they don't explicitly say "Frappe".
 ---
 
 # Frappe Full-Stack App Builder


### PR DESCRIPTION
## Summary
- Convert the `description` frontmatter value to a folded YAML string.
- This keeps the same description text while making it parse correctly.

## Problem
Running:

```bash
npx skills add netchampfaris/frappe-agent-skills --skill frappe-dev --agent codex --global --yes --copy
```

reported:

```text
No valid skills found. Skills require a SKILL.md with name and description.
```

The root cause is that the unquoted YAML description contains `mentions: creating`, and `: ` is not valid inside an unquoted plain scalar. The YAML parser reports:

```text
Nested mappings are not allowed in compact mappings at line 2, column 14
```

## Verification
```bash
npx skills add /tmp/frappe-agent-skills --skill frappe-dev --agent codex --global --yes --copy --list
```

Now reports `Found 1 skill` and lists `frappe-dev`.
