### PR TITLE
feat: add draft-security-advisory skill for writing GitHub Security Advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of agent skills for building [Frappe Framework](https://frappeframe
 | `frappe-app-dev` | Full-stack Frappe: DocTypes, controllers, APIs, database/ORM, hooks, permissions, jobs, realtime, caching, testing, app setup, frontend (Desk/Vue/portal), and the bench CLI + site management |
 | `code-style`     | General code style rules                                                                                                                                                                       |
 | `ui-design`      | General UI/UX design principles                                                                                                                                                                |
-| `ghsa`           | Write a publication-ready GitHub Security Advisory (GHSA) from a vulnerability report — title, summary, details, impact, CVSS, CWE, and PoC                                                     |
+| `draft-security-advisory` | Write a publication-ready GitHub Security Advisory (GHSA) from a vulnerability report — title, summary, details, impact, CVSS, CWE, and PoC. User-invoked only: run `/draft-security-advisory` |
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A collection of agent skills for building [Frappe Framework](https://frappeframe
 | `frappe-app-dev` | Full-stack Frappe: DocTypes, controllers, APIs, database/ORM, hooks, permissions, jobs, realtime, caching, testing, app setup, frontend (Desk/Vue/portal), and the bench CLI + site management |
 | `code-style`     | General code style rules                                                                                                                                                                       |
 | `ui-design`      | General UI/UX design principles                                                                                                                                                                |
-| `draft-security-advisory` | Write a publication-ready GitHub Security Advisory (GHSA) from a vulnerability report — title, summary, details, impact, CVSS, CWE, and PoC. User-invoked only: run `/draft-security-advisory` |
+| `draft-security-advisory` | Write a publication-ready GitHub Security Advisory (GHSA) from a vulnerability report — Impact + Workarounds body, CVSS, CWE, versions, credits. User-invoked only: run `/draft-security-advisory` |
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A collection of agent skills for building [Frappe Framework](https://frappeframe
 | `frappe-app-dev` | Full-stack Frappe: DocTypes, controllers, APIs, database/ORM, hooks, permissions, jobs, realtime, caching, testing, app setup, frontend (Desk/Vue/portal), and the bench CLI + site management |
 | `code-style`     | General code style rules                                                                                                                                                                       |
 | `ui-design`      | General UI/UX design principles                                                                                                                                                                |
+| `ghsa`           | Write a publication-ready GitHub Security Advisory (GHSA) from a vulnerability report — title, summary, details, impact, CVSS, CWE, and PoC                                                     |
 
 ## Install
 

--- a/skills/draft-security-advisory/SKILL.md
+++ b/skills/draft-security-advisory/SKILL.md
@@ -1,6 +1,7 @@
 ---
-name: ghsa
-description: Write a complete, publication-ready GitHub Security Advisory (GHSA) from a vulnerability report. Use when the user provides a vulnerability report or asks to draft/write a security advisory, GHSA, or CVE-style writeup — producing the title, summary, vulnerability details, impact, CVSS vector and score, CWE, and proof of concept. Deliberately withholds details (functions, files, fields) that would reveal the patched code path.
+name: draft-security-advisory
+description: Write a complete, publication-ready GitHub Security Advisory (GHSA) from a vulnerability report — title, summary, vulnerability details, impact, CVSS vector and score, CWE, and proof of concept. Deliberately withholds details (functions, files, fields) that would reveal the patched code path. Invoke with /draft-security-advisory and the vulnerability report.
+disable-model-invocation: true
 ---
 
 # GitHub Security Advisory Writer

--- a/skills/draft-security-advisory/SKILL.md
+++ b/skills/draft-security-advisory/SKILL.md
@@ -6,62 +6,53 @@ disable-model-invocation: true
 
 # GitHub Security Advisory Writer
 
-Turn the vulnerability report the user provides into a complete, publication-ready GitHub Security Advisory (GHSA).
+Turn the vulnerability report the user provides into a publication-ready GitHub Security Advisory (GHSA): a terse two-section body, with the precision carried by GitHub's structured form fields.
 
 ## Class, not instance
 
-The advisory speaks at the level of the vulnerability **class**: the flaw class (SSTI, SQL injection, IDOR), the broken or missing control, the product or high-level feature area, the risk category. Everything at the level of the **instance** — function names, file paths, field names, endpoints, configuration keys, code snippets, copy-paste payloads — stays out, so a reader can never work backwards from the advisory to the patched code path. This rule binds the title and every section below.
+The advisory speaks at the level of the vulnerability **class**: the flaw class (SQL injection, SSTI, missing authorization), the broken or missing control, the feature area, the risk category. Everything at the level of the **instance** — function names, file paths, field names, endpoints, configuration keys, code snippets, payloads — stays out, so a reader can never work backwards from the advisory to the patched code path. A published advisory locates a flaw no more precisely than "certain endpoints", "a configuration field", "a certain page", "names of a few records" — match that register.
 
-## Output format
+## Title
 
-First output:
+Pick the established pattern that fits; when an earlier advisory for the same project covered the same class, reuse its title verbatim — repeated titles are house style, not a defect:
 
-**Suggested title:** `{Vulnerability class} in {product or component} allows {attacker gain, 5 words or fewer}`
+- Injection flaws: `Possibility of {class} due to missing validation`
+- Authorization flaws: `Unauthorised {action} due to missing validation` (British spelling)
+- Outcome-led: `{Outcome} via {class}` — e.g. `Account takeover via Reflected XSS`
+- Feature-scoped: `{Class} in {feature area}` — e.g. `Stored XSS in Dashboards, Tools and Portals`
 
-The closing phrase names what the attacker gains ("allows unauthorized data disclosure"), never what was broken or fixed. Example: `Server-Side Template Injection in ERPNext allows unauthorized data disclosure`.
+## Advisory body
 
-Then the advisory as a single markdown document:
+Exactly two sections:
 
----
-
-## [GHSA-XXXX-XXXX-XXXX] — {same title}
-
-**Package:** {ecosystem}/{package-name}
-**Affected versions:** {range, e.g. `>= 14.0.0, < 14.62.4`}
-**Patched versions:** {version, or "Not yet patched"}
-**Severity:** {from the severity bands below}
-
-### Summary
-
-One or two sentences for a developer scanning their dependency feed: the vulnerability class and the minimum privilege level required to exploit it.
-
-### Vulnerability details
-
-3–6 sentences at the mechanism level: what kind of input is accepted, how it reaches the vulnerable operation, and which safety control is absent or broken.
-
+```markdown
 ### Impact
+{One or two sentences: where the flaw sits, at class level; what control
+was missing; what the attacker gains and the minimum privilege needed.}
 
-One to three sentences naming the risk category — "unauthorized data disclosure", "privilege escalation". Bound what is NOT achievable when that significantly changes the risk profile.
+### Workarounds
+No workaround available; upgrading is required.
+```
 
-### CVSS
+Reuse the stock Impact sentence when the class has one:
 
-**Vector:** `CVSS:3.1/AV:?/AC:?/PR:?/UI:?/S:?/C:?/I:?/A:?`
-**Score:** X.X (Severity)
+- SQL injection: "Some endpoints were vulnerable to SQL injection through specially crafted requests, which would allow a malicious actor to extract sensitive information."
+- Missing authorization: "Certain endpoints failed to enforce proper authorization checks, allowing users to modify data beyond their permitted role."
 
-One-sentence rationale for each non-obvious metric choice (PR, S, C, I).
+For other classes, write the sentence in the same register: "{Class} through {vague vector} allows {an authenticated user / a malicious user} to {capability}." Amend the Workarounds line only when a real workaround exists.
 
-### CWE
+## Form fields
 
-**Primary:** CWE-XXXX — {name}
-**Secondary (if applicable):** CWE-XXXX — {name}
+After the body, list the values for GitHub's advisory form:
 
-One sentence on why the primary CWE applies.
+- **Ecosystem / package:** the project's ecosystem and package name
+- **Affected / patched versions:** one row per supported release stream (currently v15 and v16) — affected `< {first fixed release}`, patched `{first fixed release}`
+- **CVSS:** v3.1 vector and score, derived from the rules below, with a one-sentence rationale for each non-obvious metric choice (PR, S, C, I)
+- **Severity:** the band the score falls in
+- **CWE:** the most specific id available
+- **Credits:** reporter(s) from the report as *reporter*; whoever authored the fix as *remediation developer*
 
-### Proof of concept
-
-Plain-text reproduction steps. Describe payloads and any PoC videos or write-ups in prose rather than reproducing them, so nothing is copy-paste runnable against a live system.
-
----
+That is the whole advisory: the body carries no summary, no root-cause walkthrough, and no proof of concept, and the CVE field stays empty — GitHub assigns one after publication. The report's PoC informs the CVSS metrics only.
 
 ## Derivation rules
 
@@ -83,11 +74,15 @@ Plain-text reproduction steps. Describe payloads and any PoC videos or write-ups
 - Missing authorization → CWE-862
 - Improper input validation → CWE-20
 - Code injection (generic) → CWE-94
+- Path traversal → CWE-22
+- XSS → CWE-79
+- SSRF → CWE-918
+- XXE → CWE-611
 
 **Severity bands** from the CVSS base score: 9.0–10.0 Critical · 7.0–8.9 High · 4.0–6.9 Medium · 0.1–3.9 Low.
 
-If the report supplies its own CVSS or CWE, validate it; where your analysis disagrees, use your analysis and note the discrepancy in one sentence. CVE IDs are the CNA's to assign — the advisory carries none.
+If the report supplies its own CVSS or CWE, validate it; where your analysis disagrees, use your analysis and note the discrepancy in one sentence.
 
 ## Final check
 
-The advisory is complete when every section above is present, the CVSS score falls in the stated severity band, and a re-read of the title, Summary, Vulnerability details, and Impact finds zero instance-level identifiers.
+The advisory is complete when the body is exactly Impact + Workarounds, every form field above has a value, the CVSS score falls in the stated severity band, and a re-read of the title and Impact finds zero instance-level identifiers.

--- a/skills/draft-security-advisory/SKILL.md
+++ b/skills/draft-security-advisory/SKILL.md
@@ -19,7 +19,7 @@ Pick the established pattern that fits; when an earlier advisory for the same pr
 - Injection flaws: `Possibility of {class} due to missing validation`
 - Authorization flaws: `Unauthorised {action} due to missing validation` (British spelling)
 - Outcome-led: `{Outcome} via {class}` — e.g. `Account takeover via Reflected XSS`
-- Feature-scoped: `{Class} in {feature area}` — e.g. `Stored XSS in Dashboards, Tools and Portals`
+- Feature-scoped: `{Class} in {feature area}` — a last resort, only when none of the patterns above fit; never to make a title unique, since identical titles across advisories are fine. Generalize the feature area so the exact feature stays unrevealed: name an umbrella surface one level broader than where the flaw sits (e.g. "portal pages", not the specific portal), never a module, screen, or record type.
 
 ## Advisory body
 
@@ -46,7 +46,7 @@ For other classes, write the sentence in the same register: "{Class} through {va
 After the body, list the values for GitHub's advisory form:
 
 - **Ecosystem / package:** the project's ecosystem and package name
-- **Affected / patched versions:** one row per supported release stream (currently v15 and v16) — affected `< {first fixed release}`, patched `{first fixed release}`
+- **Affected / patched versions:** one row per currently supported release stream — ask the user which streams are supported if not stated in the report; affected `< {first fixed release}`, patched `{first fixed release}`
 - **CVSS:** v3.1 vector and score, derived from the rules below, with a one-sentence rationale for each non-obvious metric choice (PR, S, C, I)
 - **Severity:** the band the score falls in
 - **CWE:** the most specific id available

--- a/skills/draft-security-advisory/SKILL.md
+++ b/skills/draft-security-advisory/SKILL.md
@@ -1,95 +1,93 @@
 ---
 name: draft-security-advisory
-description: Write a complete, publication-ready GitHub Security Advisory (GHSA) from a vulnerability report — title, summary, vulnerability details, impact, CVSS vector and score, CWE, and proof of concept. Deliberately withholds details (functions, files, fields) that would reveal the patched code path. Invoke with /draft-security-advisory and the vulnerability report.
+description: Turn a vulnerability report into a publication-ready GitHub Security Advisory.
 disable-model-invocation: true
 ---
 
 # GitHub Security Advisory Writer
 
-When the user provides a vulnerability report, produce a complete, publication-ready GitHub Security Advisory (GHSA).
+Turn the vulnerability report the user provides into a complete, publication-ready GitHub Security Advisory (GHSA).
+
+## Class, not instance
+
+The advisory speaks at the level of the vulnerability **class**: the flaw class (SSTI, SQL injection, IDOR), the broken or missing control, the product or high-level feature area, the risk category. Everything at the level of the **instance** — function names, file paths, field names, endpoints, configuration keys, code snippets, copy-paste payloads — stays out, so a reader can never work backwards from the advisory to the patched code path. This rule binds the title and every section below.
 
 ## Output format
 
-Before the advisory, output a short block:
+First output:
 
-**Suggested title:** {title — see Title rule below}
+**Suggested title:** `{Vulnerability class} in {product or component} allows {attacker gain, 5 words or fewer}`
 
-Then produce the advisory as a single markdown document structured exactly as below.
+The closing phrase names what the attacker gains ("allows unauthorized data disclosure"), never what was broken or fixed. Example: `Server-Side Template Injection in ERPNext allows unauthorized data disclosure`.
+
+Then the advisory as a single markdown document:
 
 ---
 
-## [GHSA-XXXX-XXXX-XXXX] — {same title as suggested above}
+## [GHSA-XXXX-XXXX-XXXX] — {same title}
 
 **Package:** {ecosystem}/{package-name}
-**Affected versions:** {version range, e.g. `< 15.x.x` or `>= 14.0.0, < 14.62.4`}
-**Patched versions:** {patched version or "Not yet patched"}
-**Severity:** {Critical / High / Medium / Low}
+**Affected versions:** {range, e.g. `>= 14.0.0, < 14.62.4`}
+**Patched versions:** {version, or "Not yet patched"}
+**Severity:** {from the severity bands below}
 
 ### Summary
 
-One or two sentences maximum. Name the vulnerability class and the minimum privilege level required to exploit it. Do not describe the root cause mechanically or reference specific functions, files, or data types. Write for a developer scanning their dependency feed.
+One or two sentences for a developer scanning their dependency feed: the vulnerability class and the minimum privilege level required to exploit it.
 
 ### Vulnerability details
 
-Describe the root cause precisely: what kind of input is accepted, how it reaches the vulnerable operation, and what safety control is absent or broken. Keep this at the mechanism level — name the vulnerability class and the missing control, but do not cite specific file paths, function names, field names, or endpoints, and avoid code snippets, so the advisory does not reveal the patched code path. This section should be 3–6 sentences.
+3–6 sentences at the mechanism level: what kind of input is accepted, how it reaches the vulnerable operation, and which safety control is absent or broken.
 
 ### Impact
 
-One to three sentences. Describe the risk category only — e.g., "unauthorized data disclosure" or "privilege escalation." Do not enumerate specific tables, APIs, data classes, or step-by-step attacker capabilities. Bound what is NOT achievable if that significantly changes the risk profile.
+One to three sentences naming the risk category — "unauthorized data disclosure", "privilege escalation". Bound what is NOT achievable when that significantly changes the risk profile.
 
 ### CVSS
 
 **Vector:** `CVSS:3.1/AV:?/AC:?/PR:?/UI:?/S:?/C:?/I:?/A:?`
 **Score:** X.X (Severity)
 
-Provide a one-sentence rationale for each non-obvious metric choice (PR, S, C, I).
+One-sentence rationale for each non-obvious metric choice (PR, S, C, I).
 
 ### CWE
 
-**Primary:** CWE-XXXX — {CWE name}
-**Secondary (if applicable):** CWE-XXXX — {CWE name}
+**Primary:** CWE-XXXX — {name}
+**Secondary (if applicable):** CWE-XXXX — {name}
 
-One sentence explaining why this CWE applies.
+One sentence on why the primary CWE applies.
 
 ### Proof of concept
 
-Describe the reproduction steps in plain text. Do not include working exploit payloads that could be directly copy-pasted to attack live systems. Reference any PoC videos or write-ups by description only.
+Plain-text reproduction steps. Describe payloads and any PoC videos or write-ups in prose rather than reproducing them, so nothing is copy-paste runnable against a live system.
 
 ---
 
-## Analysis rules
+## Derivation rules
 
-**Title:** Format as `{Vulnerability class} in {product/component name} allows {impact in 5 words or fewer}`.
+**CVSS metrics**, from the report:
 
-Rules:
-- Name only the vulnerability class (e.g., SSTI, SQL Injection, IDOR) and the product or high-level feature area — never a specific function name, file path, field name, or configuration key.
-- The impact phrase must describe what the attacker gains, not what was broken or fixed (e.g., "allows data disclosure", not "due to missing input validation").
-- A reader should not be able to infer which code path was changed or what the patch touches.
-- Example: `Server-Side Template Injection in ERPNext allows unauthorized data disclosure`.
+- AV — Network if reachable via web UI; Local if shell access is required.
+- AC — Low, unless the report describes a race condition, non-default setup, or hard-to-meet precondition.
+- PR — None if unauthenticated; Low for any authenticated user or common operational role; High for admin/superuser only.
+- UI — None, unless a victim must take an action.
+- S — Changed when the exploit reaches resources outside the attacker's own authorization scope (cross-tenant data, document types the role cannot normally access).
+- C — High if arbitrary sensitive records are readable; Medium if limited; None otherwise.
+- I — High for arbitrary writes or deletes; Low for constrained or incidental writes; None if read-only.
+- A — High if service disruption is possible; None otherwise.
 
-**CVSS metrics** — derive from the report:
-- AV: Network if reachable via web UI; Local if shell access required.
-- AC: Low unless the report describes a race condition, specific non-default setup, or hard-to-meet precondition.
-- PR: None if unauthenticated; Low if any authenticated user or a common operational role; High if admin/superuser only.
-- UI: None unless a victim must take an action.
-- S: Changed if the exploit reaches resources outside the attacker's own authorization scope (cross-tenant data, other document types the role cannot normally access).
-- C: High if the attacker can read arbitrary sensitive records; Medium if limited; None if no confidentiality impact.
-- I: High if arbitrary writes or deletes; Low if write is constrained or incidental; None if read-only.
-- A: High if service disruption is possible; None if not described.
+**CWE** — the most specific available:
 
-**CWE selection:** Use the most specific CWE available.
 - Template injection → CWE-1336
 - SQL injection → CWE-89
 - Missing authorization → CWE-862
 - Improper input validation → CWE-20
 - Code injection (generic) → CWE-94
 
-**Severity label** from CVSS base score:
-- 9.0–10.0 → Critical
-- 7.0–8.9 → High
-- 4.0–6.9 → Medium
-- 0.1–3.9 → Low
+**Severity bands** from the CVSS base score: 9.0–10.0 Critical · 7.0–8.9 High · 4.0–6.9 Medium · 0.1–3.9 Low.
 
-If the report already provides a CWE or CVSS, validate it. If it disagrees with your analysis, use your analysis and note the discrepancy briefly.
+If the report supplies its own CVSS or CWE, validate it; where your analysis disagrees, use your analysis and note the discrepancy in one sentence. CVE IDs are the CNA's to assign — the advisory carries none.
 
-Do not speculate about or assign a CVE ID.
+## Final check
+
+The advisory is complete when every section above is present, the CVSS score falls in the stated severity band, and a re-read of the title, Summary, Vulnerability details, and Impact finds zero instance-level identifiers.

--- a/skills/ghsa/SKILL.md
+++ b/skills/ghsa/SKILL.md
@@ -30,7 +30,7 @@ One or two sentences maximum. Name the vulnerability class and the minimum privi
 
 ### Vulnerability details
 
-Describe the root cause precisely: what input is accepted, how it flows to the sink, and what safety control is absent or broken. Reference the relevant file path and function name. Include a short code snippet only if it materially aids understanding. This section should be 3–6 sentences.
+Describe the root cause precisely: what kind of input is accepted, how it reaches the vulnerable operation, and what safety control is absent or broken. Keep this at the mechanism level — name the vulnerability class and the missing control, but do not cite specific file paths, function names, field names, or endpoints, and avoid code snippets, so the advisory does not reveal the patched code path. This section should be 3–6 sentences.
 
 ### Impact
 

--- a/skills/ghsa/SKILL.md
+++ b/skills/ghsa/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: ghsa
+description: Write a complete, publication-ready GitHub Security Advisory (GHSA) from a vulnerability report. Use when the user provides a vulnerability report or asks to draft/write a security advisory, GHSA, or CVE-style writeup — producing the title, summary, vulnerability details, impact, CVSS vector and score, CWE, and proof of concept. Deliberately withholds details (functions, files, fields) that would reveal the patched code path.
+---
+
+# GitHub Security Advisory Writer
+
+When the user provides a vulnerability report, produce a complete, publication-ready GitHub Security Advisory (GHSA).
+
+## Output format
+
+Before the advisory, output a short block:
+
+**Suggested title:** {title — see Title rule below}
+
+Then produce the advisory as a single markdown document structured exactly as below.
+
+---
+
+## [GHSA-XXXX-XXXX-XXXX] — {same title as suggested above}
+
+**Package:** {ecosystem}/{package-name}
+**Affected versions:** {version range, e.g. `< 15.x.x` or `>= 14.0.0, < 14.62.4`}
+**Patched versions:** {patched version or "Not yet patched"}
+**Severity:** {Critical / High / Medium / Low}
+
+### Summary
+
+One or two sentences maximum. Name the vulnerability class and the minimum privilege level required to exploit it. Do not describe the root cause mechanically or reference specific functions, files, or data types. Write for a developer scanning their dependency feed.
+
+### Vulnerability details
+
+Describe the root cause precisely: what input is accepted, how it flows to the sink, and what safety control is absent or broken. Reference the relevant file path and function name. Include a short code snippet only if it materially aids understanding. This section should be 3–6 sentences.
+
+### Impact
+
+One to three sentences. Describe the risk category only — e.g., "unauthorized data disclosure" or "privilege escalation." Do not enumerate specific tables, APIs, data classes, or step-by-step attacker capabilities. Bound what is NOT achievable if that significantly changes the risk profile.
+
+### CVSS
+
+**Vector:** `CVSS:3.1/AV:?/AC:?/PR:?/UI:?/S:?/C:?/I:?/A:?`
+**Score:** X.X (Severity)
+
+Provide a one-sentence rationale for each non-obvious metric choice (PR, S, C, I).
+
+### CWE
+
+**Primary:** CWE-XXXX — {CWE name}
+**Secondary (if applicable):** CWE-XXXX — {CWE name}
+
+One sentence explaining why this CWE applies.
+
+### Proof of concept
+
+Describe the reproduction steps in plain text. Do not include working exploit payloads that could be directly copy-pasted to attack live systems. Reference any PoC videos or write-ups by description only.
+
+---
+
+## Analysis rules
+
+**Title:** Format as `{Vulnerability class} in {product/component name} allows {impact in 5 words or fewer}`.
+
+Rules:
+- Name only the vulnerability class (e.g., SSTI, SQL Injection, IDOR) and the product or high-level feature area — never a specific function name, file path, field name, or configuration key.
+- The impact phrase must describe what the attacker gains, not what was broken or fixed (e.g., "allows data disclosure", not "due to missing input validation").
+- A reader should not be able to infer which code path was changed or what the patch touches.
+- Example: `Server-Side Template Injection in ERPNext allows unauthorized data disclosure`.
+
+**CVSS metrics** — derive from the report:
+- AV: Network if reachable via web UI; Local if shell access required.
+- AC: Low unless the report describes a race condition, specific non-default setup, or hard-to-meet precondition.
+- PR: None if unauthenticated; Low if any authenticated user or a common operational role; High if admin/superuser only.
+- UI: None unless a victim must take an action.
+- S: Changed if the exploit reaches resources outside the attacker's own authorization scope (cross-tenant data, other document types the role cannot normally access).
+- C: High if the attacker can read arbitrary sensitive records; Medium if limited; None if no confidentiality impact.
+- I: High if arbitrary writes or deletes; Low if write is constrained or incidental; None if read-only.
+- A: High if service disruption is possible; None if not described.
+
+**CWE selection:** Use the most specific CWE available.
+- Template injection → CWE-1336
+- SQL injection → CWE-89
+- Missing authorization → CWE-862
+- Improper input validation → CWE-20
+- Code injection (generic) → CWE-94
+
+**Severity label** from CVSS base score:
+- 9.0–10.0 → Critical
+- 7.0–8.9 → High
+- 4.0–6.9 → Medium
+- 0.1–3.9 → Low
+
+If the report already provides a CWE or CVSS, validate it. If it disagrees with your analysis, use your analysis and note the discrepancy briefly.
+
+Do not speculate about or assign a CVE ID.


### PR DESCRIPTION
Adds a user-invoked `draft-security-advisory` skill that turns a vulnerability report into a publication-ready GitHub Security Advisory, invoked explicitly with `/draft-security-advisory`.

**What it produces:** the advisory exactly as it gets published — a suggested title following the established title patterns, a two-section body (**Impact** + **Workarounds**) using the stock house phrasing, and the values for GitHub's advisory form fields: affected/patched versions per supported release stream, CVSS v3.1 vector and score with per-metric rationale, CWE, and reporter/remediation-developer credits. Includes derivation rules for CVSS metrics, a CWE lookup, and severity bands, and validates any CVSS/CWE the report already provides.

**Design intent:** the skill's core rule is *class, not instance* — every reader-facing sentence names only the vulnerability class and a deliberately vague locus ("certain endpoints", "a configuration field"), never a function, file, field, endpoint, or config key, so a reader cannot work backwards from the advisory to the patched code path. The body carries no PoC and no CVE; the report's PoC informs the CVSS metrics only. The output spec is modeled on how published advisories in this style are actually written, while the skill text itself stays project-agnostic.

**Per review:** `disable-model-invocation: true` keeps the skill user-invoked only, so its description never loads into the system prompt by default.

Follows the repo layout: `skills/draft-security-advisory/SKILL.md` with `name`/`description` frontmatter, and a README table entry.