### PR TITLE
skill: Simplified Technical English for writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Frappe Skills
 
-A collection of agent skills for building [Frappe Framework](https://frappeframework.com/) applications, plus general code-style and UI design skills.
+A collection of agent skills for building [Frappe Framework](https://frappeframework.com/) applications, plus general skills for code style, code review, writing, and UI design.
 
 ## Skills
 
-| Skill            | What it covers                                                                                                                                                                                 |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Skill | What it covers |
+| ----- | -------------- |
 | `frappe-app-dev` | Full-stack Frappe: DocTypes, controllers, APIs, database/ORM, hooks, permissions, jobs, realtime, caching, testing, app setup, frontend (Desk/Vue/portal), and the bench CLI + site management |
-| `code-style`     | General code style rules                                                                                                                                                                       |
-| `ui-design`      | General UI/UX design principles                                                                                                                                                                |
+| `quality-code-review` | Review checklist for Frappe applications: correctness, security, performance, concurrency, readability, API design, and testing |
+| `code-style` | General code style rules |
+| `technical-writing` | Write documentation, READMEs, commits, pull requests, and release notes in Simplified Technical English |
+| `ui-design` | General UI/UX design principles |
 | `draft-security-advisory` | Write a publication-ready GitHub Security Advisory (GHSA) from a vulnerability report — Impact + Workarounds body, CVSS, CWE, versions, credits. User-invoked only: run `/draft-security-advisory` |
 
 ## Install
@@ -36,4 +38,6 @@ Skills are matched by the `name` field in each `SKILL.md` frontmatter, and live 
 
 ## Usage
 
-Once installed, each skill activates automatically when you ask your agent about a matching task — creating DocTypes, building a Vue SPA, or running `bench migrate` (`frappe-app-dev`); enforcing code style (`code-style`); UI/UX judgment (`ui-design`); and so on.
+Most skills activate automatically when you ask your agent about a matching task. Examples: create a DocType, build a Vue SPA, or run `bench migrate` (`frappe-app-dev`), review a diff (`quality-code-review`), write a commit message (`technical-writing`), or lay out a page (`ui-design`).
+
+Some skills only run when you call them. Run `/draft-security-advisory` to start that skill.

--- a/skills/technical-writing/SKILL.md
+++ b/skills/technical-writing/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: technical-writing
+description: 'Write prose in "Simplified Technical English". This applies to documentation, READMEs, commits, pull request, plans and release notes. It does not apply to code, identifiers, marketing copy, essays, or anything that needs a voice.'
+---
+
+## Rules
+
+WORDS
+- Use one name for one thing. Do not call the same item by two different names.
+- Use the short common word: start (not begin/commence/initiate), use (not utilize/leverage), help (not facilitate), make sure (not ensure), before (not prior to), after (not subsequent to), about (not regarding/concerning), get (not obtain/acquire), show (not demonstrate), also (not additionally/furthermore/moreover).
+- Give each word one meaning. "fall" means to move down, not to decrease.
+- No marketing adjectives: seamless, robust, powerful, cutting-edge, effortless, world-class, next-generation, revolutionary.
+- American spelling.
+
+VERBS
+- Active voice. "the parser reads the file", not "the file is read by the parser".
+- Use a verb for an action. "analyze the log", not "perform an analysis of the log".
+- No stacked auxiliaries. Not "it is important to note that this may help to improve". Write "this improves X".
+- No "-ing" main verb where a simple tense works.
+
+SENTENCES
+- One instruction per sentence. Max 20 words (instruction), max 25 (descriptive).
+- No contractions. Use articles: a, an, the, this, these.
+
+PUNCTUATION
+- No semicolons. Write two sentences. (Note: the em dash is not banned by STE, only the semicolon is — add "no em dash" yourself if you want it gone.)
+
+STRUCTURE
+- One topic per paragraph, max six sentences. For steps, use a numbered vertical list, one action per item, imperative form. Put a condition before its command.
+
+Write only the requested text. No preamble, no summary, no closing remarks.


### PR DESCRIPTION
ref: https://en.wikipedia.org/wiki/Simplified_Technical_English

Adds a `technical-writing` skill. It holds Simplified Technical English rules for documentation, READMEs, commit messages, pull requests, plans, and release notes. The rules do not apply to code, identifiers, or marketing copy.

Anecdotal sample: https://gist.github.com/ankush/8d762ee1b5a3c871edb797e31d164596 